### PR TITLE
Add synctimer getter and so on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,12 +36,11 @@ target_sources(libzl
         lib/QPainterContext.cpp
         lib/WaveFormItem.cpp)
 
-set_target_properties(libzl
-    PROPERTIES
-        PUBLIC_HEADER
-            lib/libzl.h
-            lib/ClipAudioSource.h
-            lib/SyncTimer.h)
+set(libzl_headers
+    lib/libzl.h)
+set(libzl_subheaders
+    lib/ClipAudioSource.h
+    lib/SyncTimer.h)
 
 target_compile_definitions(libzl
     PUBLIC
@@ -90,8 +89,9 @@ target_include_directories(libzl
         $<TARGET_PROPERTY:libzl,INCLUDE_DIRECTORIES>)
 
 install(TARGETS libzl
-    LIBRARY DESTINATION lib
-    PUBLIC_HEADER DESTINATION include)
+    LIBRARY DESTINATION lib)
+install(FILES ${libzl_headers} DESTINATION include)
+install(FILES ${libzl_subheaders} DESTINATION include/libzl)
 
 ##############################
 #  END libzl SHARED LIBRARY  #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_AUTOMOC ON)
 
 add_subdirectory(tracktion_engine/modules/juce)
 add_subdirectory(tracktion_engine/modules)
+include_directories(tracktion_engine/modules/)
 
 find_package (PkgConfig REQUIRED)
 pkg_check_modules (W2GTK4 REQUIRED webkit2gtk-4.0)
@@ -39,6 +40,7 @@ target_sources(libzl
 set(libzl_headers
     lib/libzl.h)
 set(libzl_subheaders
+    lib/JUCEHeaders.h
     lib/ClipAudioSource.h
     lib/SyncTimer.h)
 

--- a/lib/JUCEHeaders.h
+++ b/lib/JUCEHeaders.h
@@ -7,7 +7,7 @@
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 
-#include "../tracktion_engine/modules/tracktion_engine/tracktion_engine.h"
+#include <tracktion_engine/tracktion_engine.h>
 
 namespace te = tracktion_engine;
 using namespace juce;

--- a/lib/SyncTimer.h
+++ b/lib/SyncTimer.h
@@ -1,20 +1,20 @@
 #pragma once
 
+#include <QObject>
 #include <QList>
 #include <QQueue>
 
-#include "ClipAudioSource.h"
-#include "JUCEHeaders.h"
+// #include "ClipAudioSource.h"
 
 using namespace std;
-using namespace juce;
 
-class SyncTimer : public HighResolutionTimer {
-  // HighResolutionTimer interface
+class ClipAudioSource;
+class SyncTimer : public QObject {
+  // HighResolutionTimer facade
+  Q_OBJECT
 public:
-  SyncTimer();
-  void hiResTimerCallback();
-  void setCallback(void (*functionPtr)(int));
+  explicit SyncTimer(QObject *parent = nullptr);
+  void addCallback(void (*functionPtr)(int));
   void removeCallback(void (*functionPtr)(int));
   void queueClipToStart(ClipAudioSource *clip);
   void queueClipToStop(ClipAudioSource *clip);
@@ -25,11 +25,6 @@ public:
   int getMultiplier();
 
 private:
-  int playingClipsCount = 0;
-  int beat = 0;
-  int bpm = 0;
-  int multiplier;
-  QList<void (*)(int)> callbacks;
-  QQueue<ClipAudioSource *> clipsStartQueue;
-  QQueue<ClipAudioSource *> clipsStopQueue;
+  class Private;
+  Private *d = nullptr;
 };

--- a/lib/libzl.cpp
+++ b/lib/libzl.cpp
@@ -145,12 +145,14 @@ void ClipAudioSource_destroy(ClipAudioSource *c) { elThread.destroyClip(c); }
 //////////////
 /// SynTimer API Bridge
 //////////////
+QObject* SyncTimer_instance() { return syncTimer; }
+
 void SyncTimer_startTimer(int interval) { syncTimer->start(interval); }
 
 void SyncTimer_stopTimer() { syncTimer->stop(); }
 
 void SyncTimer_registerTimerCallback(void (*functionPtr)(int)) {
-  syncTimer->setCallback(functionPtr);
+  syncTimer->addCallback(functionPtr);
 }
 
 void SyncTimer_deregisterTimerCallback(void (*functionPtr)(int)) {

--- a/lib/libzl.h
+++ b/lib/libzl.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <QObject>
+
 class ClipAudioSource;
 class SyncTimer;
 
@@ -43,6 +45,7 @@ void ClipAudioSource_destroy(ClipAudioSource *c);
 //////////////
 /// SyncTimer API Bridge
 //////////////
+QObject *SyncTimer_instance();
 void SyncTimer_startTimer(int interval);
 void SyncTimer_stopTimer();
 void SyncTimer_registerTimerCallback(void (*functionPtr)(int));


### PR DESCRIPTION
This fixes header installations and exposes SyncTimer as a QObject, adding a getter for the object on libzl.h